### PR TITLE
missing break-words

### DIFF
--- a/frontend/src/lib/ResponseDetail.svelte
+++ b/frontend/src/lib/ResponseDetail.svelte
@@ -47,7 +47,7 @@
 		<h4 class="text-text-highlight">Payload:</h4>
 		{#if isJsonResponse}
 			<div class="mr-2">
-				<pre class="whitespace-pre-wrap overflow-x-auto">{response.responseBody}</pre>
+				<pre class="whitespace-pre-wrap break-words overflow-x-auto">{response.responseBody}</pre>
 			</div>
 		{:else}
 			<div class="break-words mr-2">{response.responseBody}</div>


### PR DESCRIPTION
it just missed a `break-words` for me that solved the problem.

* fixed malformed overflow when no default word breaking in response exists.


*1 long response*
tested with: https://reqres.in/api/users?page=2

*multiple elements* 
tested with: https://jsonplaceholder.typicode.com/posts